### PR TITLE
refactor: allow use of pydantic v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ version = "0.4.13"
 
 [tool.poetry.dependencies]
 aiohttp = "^3.8.4"
-pydantic = "^1.9"
+pydantic = ">=1.0,<3.0"
 python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/aioopenexchangerates/model/response.py
+++ b/src/aioopenexchangerates/model/response.py
@@ -1,6 +1,9 @@
 """Provide a base response model."""
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel  # type: ignore # pragma: no cover
+except ImportError:
+    from pydantic import BaseModel  # type: ignore # pragma: no cover
 
 
 class BaseResponse(BaseModel):


### PR DESCRIPTION
See https://github.com/home-assistant/core/issues/99218 and https://github.com/home-assistant/core/actions/runs/9702211640/job/26777572563. The library's use of pydantic v1 is preventing bumping pydantic being bumped to v2 in Home Assistant.